### PR TITLE
Refactor code to handle multiple UIWindowScenes on iOS 16.0 and above

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -141,8 +141,13 @@ static UIInterfaceOrientationMask _orientationMask = UIInterfaceOrientationMaskA
 
     if (@available(iOS 16.0, *)) {
         NSArray *array = [[[UIApplication sharedApplication] connectedScenes] allObjects];
-        UIWindowScene *scene = (UIWindowScene *)array[0];    UIWindowSceneGeometryPreferencesIOS *geometryPreferences = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:mask];
-        [scene requestGeometryUpdateWithPreferences:geometryPreferences errorHandler:^(NSError * _Nonnull error) { }];
+        for (UIWindowScene *scene in array) {
+            if ([scene isKindOfClass:[UIWindowScene class]]) {
+                UIWindowSceneGeometryPreferencesIOS *geometryPreferences = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:mask];
+                [scene requestGeometryUpdateWithPreferences:geometryPreferences errorHandler:^(NSError * _Nonnull error) {
+                }];
+            }
+        }
     } else {
         UIDevice* currentDevice = [UIDevice currentDevice];
         [currentDevice setValue:@(UIInterfaceOrientationUnknown) forKey:orientation];


### PR DESCRIPTION
This pull request refactors the code to handle multiple UIWindowScenes on iOS 16.0 and above. The previous implementation assumed that there was only one UIWindowScene, that too on the zeroth index of the connectedScene array, which could lead to errors if multiple scenes were present (e.g. CarplayScene)

The new implementation uses a for loop to iterate over all connected UIWindowScenes and checks if each scene is an instance of UIWindowScene class before creating and applying the geometry preferences. This ensures that the code handles all connected UIWindowScenes correctly on iOS 16.0 and above.